### PR TITLE
Fix: Correct imu offset

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,19 +7,27 @@ find_package(catkin REQUIRED COMPONENTS
   std_msgs
   sensor_msgs
   tf2
+  tf2_eigen
   tf2_geometry_msgs
   tf_conversions
   message_generation
   geometry_msgs
   rospy
   bitbots_docs
+  rotconv
 )
+
+find_package(Eigen3 REQUIRED)
+
 enable_bitbots_docs()
 
-catkin_package()
+catkin_package(
+   CATKIN_DEPENDS tf2 rotconv
+)
 
 include_directories(
   ${catkin_INCLUDE_DIRS}
+  ${Eigen3_INCLUDE_DIRS}
 )
 
 ## Declare a C++ executable
@@ -28,4 +36,5 @@ add_executable(base_footprint src/base_footprint.cpp)
 ## Specify libraries to link a library or executable target against
 target_link_libraries(base_footprint
     ${catkin_LIBRARIES}
+    ${Eigen3_LIBRARIES}
 )

--- a/package.xml
+++ b/package.xml
@@ -20,6 +20,8 @@
   <depend>std_msgs</depend>
   <depend>sensor_msgs</depend>
   <depend>tf2</depend>
+  <depend>tf2_eigen</depend>
+  <depend>rotconv</depend>
   <depend>tf2_geometry_msgs</depend>
   <depend>tf_conversions</depend>
   <depend>geometry_msgs</depend>

--- a/src/base_footprint.cpp
+++ b/src/base_footprint.cpp
@@ -111,7 +111,7 @@ BaseFootprintBroadcaster::BaseFootprintBroadcaster() : tfBuffer(ros::Duration(10
 
             // Convert tf to eigen quaternion
             Eigen::Quaterniond eigen_quat, eigen_quat_out;
-            tf2::convert(imu_rotation, eigen_quat);
+            tf2::convert(odom.transform.rotation, eigen_quat);
 
             // Remove yaw from quaternion
             rot_conv::QuatWithEYaw(eigen_quat, yaw, eigen_quat_out);
@@ -121,7 +121,7 @@ BaseFootprintBroadcaster::BaseFootprintBroadcaster() : tfBuffer(ros::Duration(10
 
             tf2::convert(eigen_quat_out, tf_quat_out);
 
-            base_footprint.pose.orientation = f2::toMsg(tf_quat_out);
+            base_footprint.pose.orientation = tf2::toMsg(tf_quat_out);
 
             // transform the position and orientation of the base footprint into the base_link frame
             tf2::doTransform(base_footprint, base_footprint_in_base_link, support_to_base_link);


### PR DESCRIPTION
## Proposed changes
Adds the correct counter-rotation so there is no rotational difference between the `odom` and the `base_footprint` frame.

## Necessary checks
- [ ] Update package version
- [x] Run `catkin build`
- [ ] Write documentation
- [x] Test on your machine
- [x] Test on the robot
- [x] Put the PR on our Project board

