### PR TITLE
add dependencies.repos

### DIFF
--- a/.github/workflows/build_and_test_foxy.yaml
+++ b/.github/workflows/build_and_test_foxy.yaml
@@ -29,3 +29,4 @@ jobs:
       - uses: ros-tooling/action-ros-ci@v0.2
         with:
           target-ros2-distro: foxy
+          vcs-repo-file-url: dependencies.repos

--- a/.github/workflows/build_and_test_galactic.yaml
+++ b/.github/workflows/build_and_test_galactic.yaml
@@ -29,3 +29,4 @@ jobs:
       - uses: ros-tooling/action-ros-ci@v0.2
         with:
           target-ros2-distro: galactic
+          vcs-repo-file-url: dependencies.repos

--- a/.github/workflows/build_and_test_rolling.yaml
+++ b/.github/workflows/build_and_test_rolling.yaml
@@ -29,3 +29,4 @@ jobs:
       - uses: ros-tooling/action-ros-ci@v0.2
         with:
           target-ros2-distro: rolling
+          vcs-repo-file-url: dependencies.repos

--- a/dependencies.repos
+++ b/dependencies.repos
@@ -1,0 +1,5 @@
+repositories:
+  biped_interfaces:
+    type: git
+    url: https://github.com/ros-sports/biped_interfaces.git
+    version: rolling


### PR DESCRIPTION
Signed-off-by: Kenji Brameld <kenjibrameld@gmail.com>

## Proposed changes
Manually specify unreleased packages, such that CI can find and build the dependencies. This can be removed once biped_interfaces is officially released and is available through `apt install`.

Details of the method used here is descibred in [ros-tooling/action-ros-ci README](https://github.com/ros-tooling/action-ros-ci#build-with-a-custom-repos-or-rosinstall-file).

## Necessary checks
- [ ] Update package version
- [ ] Run `catkin build`
- [ ] Write documentation
- [ ] Create issues for future work
- [ ] Test on your machine
- [ ] Test on the robot
- [ ] Put the PR on our Project board

