### PR TITLE
Use rot_conv from ROS

### DIFF
--- a/.github/workflows/build_and_test_rolling.yaml
+++ b/.github/workflows/build_and_test_rolling.yaml
@@ -28,6 +28,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: ros-tooling/setup-ros@v0.3
+        with:
+          use-ros2-testing: true
       - uses: ros-tooling/action-ros-ci@v0.2
         with:
           target-ros2-distro: rolling

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@ find_package(biped_interfaces REQUIRED)
 find_package(Eigen3 REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rclcpp_components REQUIRED)
-find_package(rotconv REQUIRED)
+find_package(rot_conv REQUIRED)
 find_package(tf2_eigen REQUIRED)
 find_package(tf2_geometry_msgs REQUIRED)
 find_package(tf2_ros REQUIRED)
@@ -25,7 +25,7 @@ set(THIS_PACKAGE_INCLUDE_DEPENDS
   Eigen3
   rclcpp
   rclcpp_components
-  rotconv
+  rot_conv
   tf2_eigen
   tf2_geometry_msgs
   tf2_ros)

--- a/dependencies.repos
+++ b/dependencies.repos
@@ -3,7 +3,3 @@ repositories:
     type: git
     url: https://github.com/ros-sports/biped_interfaces.git
     version: rolling
-  rot_conv_lib:
-    type: git
-    url: https://github.com/bit-bots/rot_conv_lib.git
-    version: ros2

--- a/package.xml
+++ b/package.xml
@@ -19,7 +19,7 @@
   <depend>tf2_ros</depend>
   <depend>rclcpp_components</depend>
   <depend>eigen</depend>
-  <depend>rotconv</depend>
+  <depend>rot_conv</depend>
   <depend>biped_interfaces</depend>
 
   <test_depend>ament_lint_auto</test_depend>


### PR DESCRIPTION
Once https://github.com/ros/rosdistro/pull/32773 gets merged in, the following changes would make use of rot_conv from the ROS testing buildfarm instead of using building it from source.