### PR TITLE
Fix tf node spam

### DIFF
--- a/src/base_footprint.cpp
+++ b/src/base_footprint.cpp
@@ -35,7 +35,7 @@ namespace humanoid_base_footprint
 BaseFootprintBroadcaster::BaseFootprintBroadcaster(const rclcpp::NodeOptions &)
 : Node("base_footprint"),
   tfBuffer_(std::make_unique<tf2_ros::Buffer>(this->get_clock())),
-  tfListener_(std::make_shared<tf2_ros::TransformListener>(*tfBuffer_))
+  tfListener_(std::make_shared<tf2_ros::TransformListener>(*tfBuffer_, this))
 {
   // setup tf listener and broadcaster as class members
   base_link_frame_ = this->declare_parameter<std::string>("base_link_frame", "base_link");

--- a/test/test_base_footprint.cpp
+++ b/test/test_base_footprint.cpp
@@ -162,3 +162,12 @@ TEST_F(TestBaseFootprint, no_overlapping_time)
     tfBuffer.lookupTransform("base_link", "base_footprint", tf2::TimePointZero);
   }, tf2::TransformException);
 }
+
+TEST_F(TestBaseFootprint, test_tf_listener_node_isnt_created)
+{
+  // Ensure the tf listener does not create its own tf listener node.
+  // See https://github.com/ros-sports/humanoid_base_footprint/pull/41 for more details.
+  auto footprint_node = std::make_shared<humanoid_base_footprint::BaseFootprintBroadcaster>();
+  auto nodes = footprint_node->get_node_names();
+  ASSERT_EQ(nodes.size(), 1u);
+}

--- a/test/test_base_footprint.cpp
+++ b/test/test_base_footprint.cpp
@@ -59,7 +59,7 @@ TEST_F(TestBaseFootprint, timestamp_matching)
   br.sendTransform(tf);
 
   tf2_ros::Buffer tfBuffer{node->get_clock()};
-  tf2_ros::TransformListener tfListener{tfBuffer};
+  tf2_ros::TransformListener tfListener{tfBuffer, node};
 
   rclcpp::sleep_for(std::chrono::milliseconds(50));  // Wait for timer callback to be called
   rclcpp::spin_some(footprint_node);
@@ -105,7 +105,7 @@ TEST_F(TestBaseFootprint, timestamp_non_matching)
   br.sendTransform(tf);
 
   tf2_ros::Buffer tfBuffer{node->get_clock()};
-  tf2_ros::TransformListener tfListener{tfBuffer};
+  tf2_ros::TransformListener tfListener{tfBuffer, node};
 
   rclcpp::sleep_for(std::chrono::milliseconds(50));  // Wait for timer callback to be called
   rclcpp::spin_some(footprint_node);
@@ -151,7 +151,7 @@ TEST_F(TestBaseFootprint, no_overlapping_time)
   br.sendTransform(tf);
 
   tf2_ros::Buffer tfBuffer{node->get_clock()};
-  tf2_ros::TransformListener tfListener{tfBuffer};
+  tf2_ros::TransformListener tfListener{tfBuffer, node};
 
   rclcpp::sleep_for(std::chrono::milliseconds(50));  // Wait for timer callback to be called
   rclcpp::spin_some(footprint_node);


### PR DESCRIPTION
Passes the normal node object to the tf listener so it does not need to create its own node. The behavior in regard to parallelism should be the same, as tf creates a callback group on the node that is spon independently using a custom executor instance.

This reduces spam by "helper nodes", which are not easy to associate with the parent node and are like spam in tools like rqt node graph. It also reduces the overhead from another node instance. 